### PR TITLE
add text option to write plain text

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ var build = function(options, callback) {
   } else {
     // construct script only if transaction doesn't exist
     // if a 'transaction' attribute exists, the 'data' should be ignored to avoid confusion
-    if (options.data) {
+    if (options.data || options.text) {
       script = _script(options)
     }
   }
@@ -98,7 +98,10 @@ var send = function(options, callback) {
 // compose script
 var _script = function(options) {
   var s = null;
-  if (options.data) {
+  if (options.text) {
+    s = new bitcoin.Script();
+    s.add(Buffer.from(options.text))
+  } else if (options.data) {
     if (Array.isArray(options.data)) {
       s = new bitcoin.Script();
       // Add op_return

--- a/index.js
+++ b/index.js
@@ -99,8 +99,7 @@ var send = function(options, callback) {
 var _script = function(options) {
   var s = null;
   if (options.text) {
-    s = new bitcoin.Script();
-    s.add(Buffer.from(options.text))
+    s = bitcoin.Script.buildDataOut(options.text);
   } else if (options.data) {
     if (Array.isArray(options.data)) {
       s = new bitcoin.Script();

--- a/test/test.js
+++ b/test/test.js
@@ -20,6 +20,25 @@ describe('datapay', function() {
     })
   })
   describe('build', function() {
+    describe('text only', function() {
+      it('plain text', function(done) {
+        const options = {
+          text: "hello world"
+        }
+        datapay.build(options, function(err, tx) {
+          let generated = tx.toObject();
+          // no input (since no one has signed yet)
+          assert.equal(generated.inputs.length, 0)
+          // output has one item (only OP_RETURN)
+          assert.equal(generated.outputs.length, 1)
+          // the only existing output is a script
+          assert(generated.outputs[0].script);
+          // uses the default fee of 400
+          assert(generated.fee <= 400)
+          done()
+        });
+      })
+    })
     describe('data only', function() {
       it('push data array', function(done) {
         const options = {
@@ -51,6 +70,24 @@ describe('datapay', function() {
           assert.equal(generated.outputs.length, 1)
           // the only existing output is a script
           assert(generated.outputs[0].script);
+          // uses the default fee of 400
+          assert(generated.fee <= 400)
+
+          done()
+        });
+      })
+      it('data as text string that represents text should fail', function(done) {
+        const options = {
+          data: "use text key to pass text instead"
+        }
+        datapay.build(options, function(err, tx) {
+          let generated = tx.toObject();
+          // no input (since no one has signed yet)
+          assert.equal(generated.inputs.length, 0)
+          // output has one item (only OP_RETURN)
+          assert.equal(generated.outputs.length, 1)
+          // the only existing output is an empty script
+          assert.equal(generated.outputs[0].script.length, 0);
           // uses the default fee of 400
           assert(generated.fee <= 400)
 


### PR DESCRIPTION
Proposal: add text to build options to write plain text to blockchain. This makes datapay do the text to hex conversion instead of every client having to do it.
Problem: As a client I would expect data:"hello" to just write the text to script output. Instead build does not generate any output
Workaround: client has to encode text has hex and pass it to options.data
Solution: add options.text to hold plain text and let datapay encode it

If you think it is valuable then please merge. Otherwise I will use the work around.
