### PR TITLE
use api.bitindex.network as the default endpoint to broadcast the transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ var config = {
   data: ["0x6d02", "hello from datapay"],
   pay: {
     key: "5JZ4RXH4MoXpaUQMcJHo8DxhZtkf5U5VnYd9zZH8BRKZuAbxZEw",
-    rpc: "https://bchsvexplorer.com",
+    rpc: "https://api.bitindex.network",
     fee: 400,
     to: [{
       address: "1A2JN4JAUoKCQ5kA4pHhu4qCqma8jZSU81",
@@ -96,7 +96,7 @@ Above config describes a transaction that:
 - Posts `"hello from datapay"` to [memo.cash](https://memo.cash) network (See the protocol at [https://memo.cash/protocol](https://memo.cash/protocol)),
 - paying the fee of `400` satoshis,
 - signed with a private key: `5JZ4RXH4MoXpaUQMcJHo8DxhZtkf5U5VnYd9zZH8BRKZuAbxZEw`,
-- through a public JSON-RPC endpoint at [https://bchsvexplorer.com](https://bchsvexplorer.com)
+- through a public JSON-RPC endpoint at [https://api.bitindex.network](https://api.bitindex.network)
 - while tipping the user `1A2JN4JAUoKCQ5kA4pHhu4qCqma8jZSU81` a value of `1000` satoshis.
 
 All you need to do to invoke it is call:
@@ -289,14 +289,14 @@ datapay.build(tx, function(err, tx) {
 
 The `rpc` attribute is used to manually set the JSON-RPC endpoint you wish to broadcast through. 
 
-- default: `https://bchsvexplorer.com`
+- default: `https://api.bitindex.network`
 
 ```
 const tx = {
   data: ["0x6d02", "hello world"],
   pay: {
     key: "5JZ4RXH4MoXpaUQMcJHo8DxhZtkf5U5VnYd9zZH8BRKZuAbxZEw",
-    rpc: "https://bchsvexplorer.com"
+    rpc: "https://api.bitindex.network"
   }
 };
 datapay.build(tx, function(err, res) {
@@ -318,7 +318,7 @@ const tx = {
   data: ["0x6d02", "hello world"],
   pay: {
     key: "5JZ4RXH4MoXpaUQMcJHo8DxhZtkf5U5VnYd9zZH8BRKZuAbxZEw",
-    rpc: "https://bchsvexplorer.com",
+    rpc: "https://api.bitindex.network",
     fee: 400
   }
 }
@@ -546,7 +546,7 @@ Using this endpoint you can connect to a public JSON-RPC endpoint to let you mak
 datapay.connect([RPC ENDPOINT]).[METHOD]
 ```
 
-If you leave the `RPC ENDPOINT` part out, it will automatically use the default https://bchsvexplorer.com node
+If you leave the `RPC ENDPOINT` part out, it will automatically use the default https://api.bitindex.network node
 
 ### Example 1: Connecting to default node and calling `getUnspentUtxos()` method:
 
@@ -563,7 +563,7 @@ datapay.connect().getUnspentUtxos("14xMz8rKm4L83RuZdmsHXD2jvENZbv72vR", function
 ### Example 2. Specifying a JSON-RPC endpoint
 
 ```
-datapay.connect('https://bchsvexplorer.com').getUnspentUtxos("14xMz8rKm4L83RuZdmsHXD2jvENZbv72vR", function(err, utxos) {
+datapay.connect('https://api.bitindex.network').getUnspentUtxos("14xMz8rKm4L83RuZdmsHXD2jvENZbv72vR", function(err, utxos) {
   if (err) {
     console.log("Error: ", err)
   } else {

--- a/example/composer.html
+++ b/example/composer.html
@@ -122,7 +122,7 @@ var send = function(transaction) {
   })
   .then(function(response) {
     console.log(response);
-    document.querySelector("#sent").innerHTML = "<a href='https://bchsvexplorer.com/tx/" + response.txid + "' target='_blank'>Success! Click to view Transaction</a>";
+    document.querySelector("#sent").innerHTML = "<a href='https://api.bitindex.network/api/v2/tx/" + response.txid + "' target='_blank'>Success! Click to view Transaction</a>";
     document.querySelector("#sent").className = "";
     document.querySelector("#send").className = "hidden";
   })

--- a/example/composer.html
+++ b/example/composer.html
@@ -77,7 +77,7 @@ textarea {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <script src="https://unpkg.com/datapay"></script>
 <script>
-var endpoint = "https://bchsvexplorer.com/api/tx/send";
+var endpoint = "https://api.bitindex.network/api/tx/send";
 document.addEventListener("DOMContentLoaded", function(event) {
   var dslEl = document.querySelector("#dsl");
   var txEl = document.querySelector("#tx");

--- a/example/playground.html
+++ b/example/playground.html
@@ -133,7 +133,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
         .then(function(response) {
           console.log("Response = ", response)
           e.target.textContent = "Sent!";
-          confirmEl.innerHTML = "<a href='https://bchsvexplorer.com/tx/" + response.txid + "' target='_blank'>Success! Click to view Transaction</a>";
+          confirmEl.innerHTML = "<a href='https://api.bitindex.network/api/v2/tx/" + response.txid + "' target='_blank'>Success! Click to view Transaction</a>";
         })
       }
     }

--- a/example/playground.html
+++ b/example/playground.html
@@ -77,7 +77,7 @@ body {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <script src="https://unpkg.com/datapay"></script>
 <script>
-var endpoint = "https://bchsvexplorer.com/api/tx/send";
+var endpoint = "https://api.bitindex.network/api/tx/send";
 var transaction = null;
 var selected = null;
 var sending = false;

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const _Buffer = require('buffer/')
 const bitcoin = require('bsv');
 const explorer = require('bitcore-explorers');
 const defaults = {
-  rpc: "https://bchsvexplorer.com",
+  rpc: "https://api.bitindex.network",
   fee: 400
 }
 // The end goal of 'build' is to create a hex formated transaction object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datapay",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "post data over bitcoin sv",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -573,12 +573,12 @@ describe('datapay', function() {
       it('default', function() {
         var insight = datapay.connect();
         assert.equal(insight.constructor.name, "Insight")
-        assert.equal(insight.url, 'https://bchsvexplorer.com')
+        assert.equal(insight.url, 'https://api.bitindex.network')
       })
       it('connect with url', function() {
-        var insight = datapay.connect('https://bchsvexplorer2.com');
+        var insight = datapay.connect('https://api.bitindex.network');
         assert.equal(insight.constructor.name, "Insight")
-        assert.equal(insight.url, 'https://bchsvexplorer2.com')
+        assert.equal(insight.url, 'https://api.bitindex.network')
       })
     })
   })


### PR DESCRIPTION
bchsvexplorer.com has not upgraded to allow a larger tx and the owner can't be located.

The owner of bitindex.network is active on social media and can be contacted when issues arrise thus seems to be a better default endpoint long term.