### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,11 @@
   "unpkg": "dist/datapay.min.js",
   "dependencies": {
     "bitcore-explorers": "^1.0.1",
-    "bsv": "0.24.5",
     "buffer": "^5.2.1",
     "mingo": "^2.2.4"
+  },
+  "peerDependencies": {
+    "bsv": "0.24.5"
   },
   "files": [
     "dist"


### PR DESCRIPTION
move bsv from dependencies to peerDependencies, to avoid bsv version guard.
> More than one instance of bsv found. Please make sure to require bsv and check that submodules do not also include their own bsv dependency.