### PR TITLE
Added "change" attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ var config = {
       address: "1A2JN4JAUoKCQ5kA4pHhu4qCqma8jZSU81",
       value: 1000
     }]
-  }
+  },
+  change: "1CBtFi158ieej44LJ9XkoGuH99t1BFh15j"
 }
 ```
 
@@ -432,6 +433,32 @@ datapay.build(tx, function(err, tx) {
   /**
   * res contains the generated transaction object
   * (a signed transaction, since 'key' is included)
+  **/
+})
+```
+
+
+#### 6. `change`
+
+The `change` attribute is used to optionally specify where change for unspent funds pays out to, making it easy to implement single-use addresses.
+
+- default: sender's address
+
+```
+const tx = {
+  safe: true,
+  data: ["0x6d02", "hello world"],
+  pay: {
+    key: "5JZ4RXH4MoXpaUQMcJHo8DxhZtkf5U5VnYd9zZH8BRKZuAbxZEw",
+  },
+  change: "1CBtFi158ieej44LJ9XkoGuH99t1BFh15j"
+}
+datapay.build(tx, function(err, res) {
+  /**
+  * res contains the generated transaction object
+  * (a signed transaction, since 'key' is included.)
+  * It also pays any unspent change to the address
+  * in the change field instead of returning to sender.
   **/
 })
 ```

--- a/index.js
+++ b/index.js
@@ -62,8 +62,10 @@ var build = function(options, callback) {
           tx.to(receiver.address, receiver.value)
         })
       }
-
-      tx.fee(defaults.fee).change(address);
+      
+      //Pay remaining outputs to next address if defined, or default back to sender's address
+      const change = options.change ? new bitcoin.Address.fromString(options.change) : address;
+      tx.fee(defaults.fee).change(change);
       let opt_pay = options.pay || {};
       let myfee = opt_pay.fee || Math.ceil(tx._estimateSize()* (opt_pay.feeb || defaults.feeb));
       tx.fee(myfee);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "mingo": "^2.2.4"
   },
   "peerDependencies": {
-    "bsv": "0.27.1"
+    "bsv": "0.30.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
In order to help people implement single-use addresses, a "change" attribute has been added to the config object enabling users to specify the next address they will use to spend their change as opposed to being locked into address reuse. Also added documentation and updated to the latest version of bsv.js.