### PR TITLE
api.bitindex.network is depricated. use api.mattercloud.net instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ var config = {
   data: ["0x6d02", "hello from datapay"],
   pay: {
     key: "5JZ4RXH4MoXpaUQMcJHo8DxhZtkf5U5VnYd9zZH8BRKZuAbxZEw",
-    rpc: "https://api.bitindex.network",
+    rpc: "https://api.mattercloud.net",
     fee: 400,
     to: [{
       address: "1A2JN4JAUoKCQ5kA4pHhu4qCqma8jZSU81",
@@ -101,7 +101,7 @@ Above config describes a transaction that:
 - Posts `"hello from datapay"` to [memo.cash](https://memo.cash) network (See the protocol at [https://memo.cash/protocol](https://memo.cash/protocol)),
 - paying the fee of `400` satoshis,
 - signed with a private key: `5JZ4RXH4MoXpaUQMcJHo8DxhZtkf5U5VnYd9zZH8BRKZuAbxZEw`,
-- through a public JSON-RPC endpoint at [https://api.bitindex.network](https://api.bitindex.network)
+- through a public JSON-RPC endpoint at [https://api.mattercloud.net](https://api.mattercloud.net)
 - while tipping the user `1A2JN4JAUoKCQ5kA4pHhu4qCqma8jZSU81` a value of `1000` satoshis.
 
 All you need to do to invoke it is call:
@@ -301,7 +301,7 @@ datapay.build(tx, function(err, tx) {
 
 The `rpc` attribute is used to manually set the JSON-RPC endpoint you wish to broadcast through. 
 
-- default: `https://api.bitindex.network`
+- default: `https://api.mattercloud.net`
 
 ```
 const tx = {
@@ -309,7 +309,7 @@ const tx = {
   data: ["0x6d02", "hello world"],
   pay: {
     key: "5JZ4RXH4MoXpaUQMcJHo8DxhZtkf5U5VnYd9zZH8BRKZuAbxZEw",
-    rpc: "https://api.bitindex.network"
+    rpc: "https://api.mattercloud.net"
   }
 };
 datapay.build(tx, function(err, res) {
@@ -332,7 +332,7 @@ const tx = {
   data: ["0x6d02", "hello world"],
   pay: {
     key: "5JZ4RXH4MoXpaUQMcJHo8DxhZtkf5U5VnYd9zZH8BRKZuAbxZEw",
-    rpc: "https://api.bitindex.network",
+    rpc: "https://api.mattercloud.net",
     fee: 400
   }
 }
@@ -356,7 +356,7 @@ const tx = {
   data: ["0x6d02", "hello world"],
   pay: {
     key: "5JZ4RXH4MoXpaUQMcJHo8DxhZtkf5U5VnYd9zZH8BRKZuAbxZEw",
-    rpc: "https://api.bitindex.network",
+    rpc: "https://api.mattercloud.net",
     feeb: 1.04
   }
 }
@@ -589,7 +589,7 @@ Using this endpoint you can connect to a public JSON-RPC endpoint to let you mak
 datapay.connect([RPC ENDPOINT]).[METHOD]
 ```
 
-If you leave the `RPC ENDPOINT` part out, it will automatically use the default https://api.bitindex.network node
+If you leave the `RPC ENDPOINT` part out, it will automatically use the default https://api.mattercloud.net node
 
 ### Example 1: Connecting to default node and calling `getUnspentUtxos()` method:
 
@@ -606,7 +606,7 @@ datapay.connect().getUnspentUtxos("14xMz8rKm4L83RuZdmsHXD2jvENZbv72vR", function
 ### Example 2. Specifying a JSON-RPC endpoint
 
 ```
-datapay.connect('https://api.bitindex.network').getUnspentUtxos("14xMz8rKm4L83RuZdmsHXD2jvENZbv72vR", function(err, utxos) {
+datapay.connect('https://api.mattercloud.net').getUnspentUtxos("14xMz8rKm4L83RuZdmsHXD2jvENZbv72vR", function(err, utxos) {
   if (err) {
     console.log("Error: ", err)
   } else {

--- a/example/composer.html
+++ b/example/composer.html
@@ -77,7 +77,10 @@ textarea {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <script src="https://unpkg.com/datapay@0.0.17/dist/datapay.min.js"></script>
 <script>
-var endpoint = "https://api.bitindex.network/api/tx/send";
+var endpoint = "https://api.mattercloud.net/api/v3/main/tx/send"; // alternative: 'https://api.whatsonchain.com/v1/bsv/main/tx/raw'
+var rawTxKey = 'rawtx'; // use 'txhex' for api.whatsonchain.com
+var apiKey = ''; // only needed for api.mattercloud.net when exeeding 3 tx per 15 seconds.
+                 // Get the API key from https://www.mattercloud.net/#get-api-key
 document.addEventListener("DOMContentLoaded", function(event) {
   var dslEl = document.querySelector("#dsl");
   var txEl = document.querySelector("#tx");
@@ -109,20 +112,25 @@ document.addEventListener("DOMContentLoaded", function(event) {
   update(dslEl.value)
 })
 var send = function(transaction) {
+  header = {
+    'Accept': 'application/json',
+    'Content-Type': 'application/json'
+  };
+
+  if (apiKey.length > 0)
+    header.apikey = apiKey;
+  
   fetch(endpoint, {
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json'
-    },
+    headers: header,
     method: 'POST',
-    body: JSON.stringify({rawtx: transaction})
+    body: `{"${rawTxKey}": "${transaction.toString()}"}`
   })
   .then(function(res) {
     return res.json();
   })
   .then(function(response) {
     console.log(response);
-    document.querySelector("#sent").innerHTML = "<a href='https://api.bitindex.network/api/v2/tx/" + response.txid + "' target='_blank'>Success! Click to view Transaction</a>";
+    document.querySelector("#sent").innerHTML = "<a href='https://whatsonchain.com/tx/" + response.txid + "' target='_blank'>Success! Click to view Transaction</a>";
     document.querySelector("#sent").className = "";
     document.querySelector("#send").className = "hidden";
   })

--- a/example/playground.html
+++ b/example/playground.html
@@ -77,7 +77,10 @@ body {
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <script src="https://unpkg.com/datapay@0.0.17/dist/datapay.min.js"></script>
 <script>
-var endpoint = "https://api.bitindex.network/api/tx/send";
+var endpoint = "https://api.mattercloud.net/api/v3/main/tx/send"; // alternative: 'https://api.whatsonchain.com/v1/bsv/main/tx/raw'
+var rawTxKey = 'rawtx'; // use 'txhex' for api.whatsonchain.com
+var apiKey = ''; // only needed for api.mattercloud.net when exeeding 3 tx per 15 seconds.
+                 // Get the API key from https://www.mattercloud.net/#get-api-key
 var transaction = null;
 var selected = null;
 var sending = false;
@@ -119,13 +122,18 @@ document.addEventListener("DOMContentLoaded", function(event) {
       } else {
         e.target.textContent = "Sending...";
         sending = true;
+        header = {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        };
+
+        if (apiKey.length > 0)
+          header.apikey = apiKey;
+
         fetch(endpoint, {
-          headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-          },
+          headers: header,
           method: 'POST',
-          body: JSON.stringify({rawtx: transaction.toString()})
+          body: `{"${rawTxKey}": "${transaction.toString()}"}`
         })
         .then(function(res) {
           return res.json();
@@ -133,7 +141,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
         .then(function(response) {
           console.log("Response = ", response)
           e.target.textContent = "Sent!";
-          confirmEl.innerHTML = "<a href='https://api.bitindex.network/api/v2/tx/" + response.txid + "' target='_blank'>Success! Click to view Transaction</a>";
+          confirmEl.innerHTML = "<a href='https://whatsonchain.com/tx/" + response.txid + "' target='_blank'>Success! Click to view Transaction</a>";
         })
       }
     }

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const _Buffer = require('buffer/')
 const bitcoin = require('bsv');
 const explorer = require('bitcore-explorers');
 const defaults = {
-  rpc: "https://api.bitindex.network",
+  rpc: "api.mattercloud.net",
   fee: 400,
   feeb: 1.4
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,20 @@
 {
   "name": "datapay",
-  "version": "0.0.15",
+  "version": "0.0.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "aes-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ=="
+    },
     "ajv": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.2.tgz",
-      "integrity": "sha512-FBHEW6Jf5TB9MGBgUUA9XHkTbjXYfAUjY43ACMfmdMRHniyoMHjHjzD50OK8LGDWQwp4rWEsIq5kEqq7rvIM1g==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.11.0.tgz",
+      "integrity": "sha512-nCprB/0syFYy9fVYU1ox1l2KN8S9I+tziH8D4zdZuLT3N6RMlGSGt5FSTpAiHB/Whv8Qs1cWHma1aMKZyaHRKA==",
       "requires": {
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
@@ -39,15 +44,23 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base-x": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.7.tgz",
+      "integrity": "sha512-zAKJGuQPihXW22fkrfOclUUZXM2g92z5GzlSMHxhO6r6Qj+Nm0ccaGNBzDZojzwOMkpjAv4J0fOv1U4go+a4iw==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "base64-js": {
       "version": "1.3.0",
@@ -118,7 +131,7 @@
             },
             "hash.js": {
               "version": "1.0.3",
-              "resolved": "http://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
               "integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
               "requires": {
                 "inherits": "^2.0.1"
@@ -133,10 +146,15 @@
         },
         "lodash": {
           "version": "3.10.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
+    },
+    "bn.js": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -148,6 +166,11 @@
         "concat-map": "0.0.1"
       }
     },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+    },
     "browser-request": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
@@ -158,6 +181,36 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "requires": {
+        "base-x": "^3.0.2"
+      }
+    },
+    "bsv": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bsv/-/bsv-1.2.0.tgz",
+      "integrity": "sha512-Hccrppea561dus7v/5OZsSWClsPYLFd+kQjdRRkR5Ky+fuwlJYtMdJWGR7nuLUKqWyZwkBI5lLocXERvZ/zSkg==",
+      "requires": {
+        "aes-js": "^3.1.2",
+        "bn.js": "=4.11.8",
+        "bs58": "=4.0.1",
+        "clone-deep": "^4.0.1",
+        "elliptic": "6.4.1",
+        "hash.js": "^1.1.7",
+        "inherits": "2.0.3",
+        "unorm": "1.4.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+        }
+      }
     },
     "buffer": {
       "version": "5.2.1",
@@ -173,10 +226,20 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
+    "clone-deep": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      }
+    },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -232,6 +295,20 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "elliptic": {
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+      "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -249,14 +326,14 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -327,11 +404,37 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        }
+      }
+    },
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
     },
     "http-signature": {
       "version": "1.2.0",
@@ -361,13 +464,25 @@
     "inherits": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-      "dev": true
+      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isstream": {
       "version": "0.1.2",
@@ -405,23 +520,38 @@
         "verror": "1.10.0"
       }
     },
+    "kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+    },
     "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.43.0"
       }
     },
     "mingo": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/mingo/-/mingo-2.2.8.tgz",
       "integrity": "sha512-61ET/PK45Jm1yWfoiYL/9KBs/+66s4ctLJeMCnKgYJlrD46oqbIVnfm5RbDyqo9Gl19mzUUi4DDvTlMzirzKVw=="
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -509,9 +639,9 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
     },
     "punycode": {
       "version": "2.1.1",
@@ -560,6 +690,14 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "shallow-clone": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -567,9 +705,9 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.0.tgz",
-      "integrity": "sha512-Zhev35/y7hRMcID/upReIvRse+I9SVhyVre/KTJSJQWMz3C3+G+HpO7m1wK/yckEtujKZ7dS4hkVxAnmHaIGVQ==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -638,6 +776,11 @@
         }
       }
     },
+    "unorm": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unorm/-/unorm-1.4.1.tgz",
+      "integrity": "sha1-NkIA1fE2RsqLzURJAnEzVhR5IwA="
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -647,9 +790,9 @@
       }
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datapay",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "post data over bitcoin sv",
   "main": "index.js",
   "scripts": {
@@ -19,11 +19,12 @@
   "unpkg": "dist/datapay.min.js",
   "dependencies": {
     "bitcore-explorers": "^1.0.1",
+    "bsv": "^1.2.0",
     "buffer": "^5.2.1",
     "mingo": "^2.2.4"
   },
   "peerDependencies": {
-    "bsv": "0.27.1"
+    "bsv": "^1.2.0"
   },
   "files": [
     "dist"

--- a/test/test.js
+++ b/test/test.js
@@ -595,12 +595,12 @@ describe('datapay', function() {
       it('default', function() {
         var insight = datapay.connect();
         assert.equal(insight.constructor.name, "Insight")
-        assert.equal(insight.url, 'https://api.bitindex.network')
+        assert.equal(insight.url, 'https://api.mattercloud.net')
       })
       it('connect with url', function() {
-        var insight = datapay.connect('https://api.bitindex.network');
+        var insight = datapay.connect('https://api.mattercloud.net');
         assert.equal(insight.constructor.name, "Insight")
-        assert.equal(insight.url, 'https://api.bitindex.network')
+        assert.equal(insight.url, 'https://api.mattercloud.net')
       })
     })
   })


### PR DESCRIPTION
api.mattercloud.net needs an api key if the broadcast requests exceed 3 transactions / 15 seconds.
An API key is currently not supported by bitcore-explorers but we can add it for client side implementations (see examples).
